### PR TITLE
Update NameIdPolicy.cs

### DIFF
--- a/src/SAML2/Schema/Protocol/NameIdPolicy.cs
+++ b/src/SAML2/Schema/Protocol/NameIdPolicy.cs
@@ -39,7 +39,7 @@ namespace SAML2.Schema.Protocol
         [XmlAttribute("AllowCreate")]
         public string AllowCreateString
         {
-            get { return AllowCreate.HasValue ? AllowCreate.ToString() : null; }
+            get { return AllowCreate.HasValue ? AllowCreate.ToString().ToLower() : null; }
             set { AllowCreate = string.IsNullOrEmpty(value) ? (bool?)null : Convert.ToBoolean(value); }
         }
 


### PR DESCRIPTION
Microsoft Azure AD rejects SAML2 AuthRequest when boolean values contain capital letters (i.e. False instead of false).