### PR TITLE
#16 Reworking of the configuration pieces around logging, to avoid a …

### DIFF
--- a/src/SAML2.Tests/AssertionUtil.cs
+++ b/src/SAML2.Tests/AssertionUtil.cs
@@ -200,7 +200,7 @@ namespace SAML2.Tests
         {
             if (_cert == null)
             {
-                _cert = new X509Certificate2(@"Certificates\sts_dev_certificate.pfx", "test1234");
+                _cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\sts_dev_certificate.pfx", "test1234");
                 Assert.That(_cert.HasPrivateKey, "Certificate no longer contains a private key. Modify test.");
             }
 
@@ -286,7 +286,7 @@ namespace SAML2.Tests
         /// <returns>The XML document.</returns>
         public static XmlDocument LoadBase64EncodedXmlDocument(string assertionFile)
         {
-            var assertionBase64 = File.ReadAllText(@"Assertions\fobs-assertion2");
+            var assertionBase64 = File.ReadAllText(TestContext.CurrentContext.TestDirectory + @"\Assertions\fobs-assertion2");
             var assertionBytes = Convert.FromBase64String(assertionBase64);
 
             var document = new XmlDocument { PreserveWhitespace = true };

--- a/src/SAML2.Tests/Bindings/HttpRedirectBindingBuilderTests.cs
+++ b/src/SAML2.Tests/Bindings/HttpRedirectBindingBuilderTests.cs
@@ -20,7 +20,6 @@ namespace SAML2.Tests.Bindings
             /// Ensure that it is not possible to add a request, when a response has already been added.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(ArgumentException))]
             public void DoesNotAllowResponseAndRequestToBothBeSet()
             {
                 // Arrange
@@ -30,10 +29,7 @@ namespace SAML2.Tests.Bindings
                                   };
 
                 // Act
-                binding.Request = "Request";
-
-                // Assert
-                Assert.Fail("HttpRedirectBinding did not throw an exception when both Request and Response were set.");
+                Assert.Throws<ArgumentException>(() => binding.Request = "Request");
             }
         }
 
@@ -47,7 +43,6 @@ namespace SAML2.Tests.Bindings
             /// Ensure that it is not possible to add a response, when a request has already been added.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(ArgumentException))]
             public void DoesNotAllowRequestAndResponseToBothBeSet()
             {
                 // Arrange
@@ -57,10 +52,7 @@ namespace SAML2.Tests.Bindings
                                   };
 
                 // Act
-                binding.Response = "Response";
-
-                // Assert
-                Assert.Fail("HttpRedirectBinding did not throw an exception when both Request and Response were set.");
+                Assert.Throws<ArgumentException>(() => binding.Response = "Response");
             }
         }
 

--- a/src/SAML2.Tests/Bindings/HttpRedirectBindingParserTests.cs
+++ b/src/SAML2.Tests/Bindings/HttpRedirectBindingParserTests.cs
@@ -174,7 +174,7 @@ namespace SAML2.Tests.Bindings
                 // Arrange
                 var url = new Uri("http://haiku.safewhere.local/Saml20TestWeb/SSOLogout.saml2.aspx?SAMLResponse=fZFRa8IwEMe%2FSsm7bZq2qMEWZN1DwSEY0eGLpGmqZTUpuYTpt19bGVMYPob7%2FX%2BXu1sAv7QdXemTdnYjodMKpJdLsI3ittEqRWdrOxoEZ958OR94Lb%2FP0ki%2F1YK3AevjBG97fi%2FLgLH13eQPWuJz6K7IK9SveKtT1FQ1qYSoSSRIVMVhPJ3hpMQRj6IwKUVcJn0CwMlCgeXKpohgPJvgaILjbUhoQmg49cl8dui5PEWH%2BoaB6P2arAtlq%2FqWF%2FNTXn8y3yBvJw2MQxAfI%2B96aRXQceIUOaOo5tAAVfwigVpB2fJjRXuSdkZbLXSLssVA0%2FE%2F5iH%2FOs4BpBmWh7JlvnrfHIcKwcciXwQPvru8o8xy6%2BD59aYr6e146%2BTrVjDSlDkhJAAKsnuHP2nw34GzHw%3D%3D&SigAlg=http%3A%2F%2Fwww.w3.org%2F2000%2F09%2Fxmldsig%23rsa-sha1&Signature=UoYGLeSCYOSvjIaBpTcgtq2O0Nbz%2BVk%2BaaLESje8%2FZKxGNmWrFXJjSPrA403J23NeQzbxxVgOwSP8idIM95BhlVwxpiG%2B7%2FhJyNNrjGPohmD3cQpBWoWqZ8IEudDc%2FwDCshPb6wTdr6%2FOdKXQ2uwSK5NA2LYI8AAN5sq9kPtVvk%3D");
                 var parser = new HttpRedirectBindingParser(url);
-                var cert = new X509Certificate2(@"Certificates\pingcertificate.crt");
+                var cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\pingcertificate.crt");
 
                 // Act
                 var result = parser.CheckSignature(cert.PublicKey.Key);
@@ -192,7 +192,7 @@ namespace SAML2.Tests.Bindings
                 // Arrange
                 var url = new Uri("https://adler.safewhere.local:9031/idp/SSO.saml2?SAMLRequest=7b0HYBxJliUmL23Ke39K9UrX4HShCIBgEyTYkEAQ7MGIzeaS7B1pRyMpqyqBymVWZV1mFkDM7Z28995777333nvvvfe6O51OJ%2fff%2fz9cZmQBbPbOStrJniGAqsgfP358Hz8iHv8e7xZlepnXTVEtP%2ftod7zz0e9x9Bsnj3%2fR7qPjdTtfvsp%2f0Tpv2vTs6WcfFbP7ew8fPnhw%2f97%2bZC%2fbvzebPty59%2bn92b37kwc755O9g92P0p80kPYIUnrWNOv8bNm02bKlj3Z2DrZ37m3v7L%2fZ3X90b%2ffRvU%2fHDz69v%2fPw3t5PfZQSHsvm0S%2fa%2feyjdb18VGVN0TxaZou8edROH70%2b%2fuL5IwL5aFVXbTWtyo8IyTR9zB3U8u7mF7OmyeuWUPvoCM2%2bnRVv14%2fvyvsC66Razgq0aN4THt6m94%2fXsyJfTvNXRK%2b6mOI7%2fcr70u%2fcfqYA7AddCI%2fvOtwwOXc7s3P0%2fwA%3d&SigAlg=http%3a%2f%2fwww.w3.org%2f2000%2f09%2fxmldsig%23rsa-sha1&Signature=UsZV%2bFga0YfCQaozLomKfV8jyNt85GMIYLFoBA9jrwFfabL%2bpAWVmlhwHyAMv50uxJWFc57v2ySj5Pc6e1t0NyyaguRL8VOKqB4P3svXV5U4iU0Gq4Rp1SJu0bj538%2f01X8IINmcAJMLdrx1cqCoRmofEcPPoQODWhQoq%2brjZdE%3d");
                 var parser = new SAML2.Bindings.HttpRedirectBindingParser(url);
-                var cert = new X509Certificate2(@"Certificates\SafewhereTest_SFS.pfx", "test1234");
+                var cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\SafewhereTest_SFS.pfx", "test1234");
 
                 // Act
                 var result = parser.CheckSignature(cert.PublicKey.Key);
@@ -205,7 +205,6 @@ namespace SAML2.Tests.Bindings
             /// Verify parser throws exception on trying to verify signature of unsigned request.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(InvalidOperationException))]
             public void ParserThrowsExceptionWhenTryingToVerifySignatureOfUnsignedRequest()
             {
                 // Arrange
@@ -217,10 +216,7 @@ namespace SAML2.Tests.Bindings
                 var bindingParser = new HttpRedirectBindingParser(url);
 
                 // Act
-                bindingParser.CheckSignature(new RSACryptoServiceProvider());
-
-                // Assert
-                Assert.Fail("Trying to verify signature of an unsigned request should have thrown an exception.");
+                Assert.Throws<InvalidOperationException>(() => bindingParser.CheckSignature(new RSACryptoServiceProvider()));
             }
         }
     }

--- a/src/SAML2.Tests/SAML2.Tests.csproj
+++ b/src/SAML2.Tests/SAML2.Tests.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -144,6 +144,9 @@
       <Project>{75E5BAD2-A20C-43CC-B5C8-38004CEDBDFD}</Project>
       <Name>SAML2</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/SAML2.Tests/Saml20EncryptedAssertionTests.cs
+++ b/src/SAML2.Tests/Saml20EncryptedAssertionTests.cs
@@ -37,7 +37,7 @@ namespace SAML2.Tests
                                              Assertion = AssertionUtil.GetTestAssertion()
                                          };
 
-            var cert = new X509Certificate2(@"Certificates\sts_dev_certificate.pfx", "test1234");
+            var cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\sts_dev_certificate.pfx", "test1234");
             encryptedAssertion.TransportKey = (RSA)cert.PublicKey.Key;
 
             // Act
@@ -79,8 +79,8 @@ namespace SAML2.Tests
         public void HasNoAssertionBeforeDecrypt()
         {
             // Arrange
-            var doc = AssertionUtil.LoadXmlDocument(@"Assertions\EncryptedAssertion_01");
-            var cert = new X509Certificate2(@"Certificates\sts_dev_certificate.pfx", "test1234");
+            var doc = AssertionUtil.LoadXmlDocument(TestContext.CurrentContext.TestDirectory + @"\Assertions\EncryptedAssertion_01");
+            var cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\sts_dev_certificate.pfx", "test1234");
 
             // Act
             var encryptedAssertion = new Saml20EncryptedAssertion((RSA)cert.PrivateKey, doc);
@@ -102,8 +102,8 @@ namespace SAML2.Tests
             public void CanDecryptAssertion()
             {
                 // Arrange
-                var doc = AssertionUtil.LoadXmlDocument(@"Assertions\EncryptedAssertion_01");
-                var cert = new X509Certificate2(@"Certificates\sts_dev_certificate.pfx", "test1234");
+                var doc = AssertionUtil.LoadXmlDocument(TestContext.CurrentContext.TestDirectory + @"\Assertions\EncryptedAssertion_01");
+                var cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\sts_dev_certificate.pfx", "test1234");
                 var encryptedAssertion = new Saml20EncryptedAssertion((RSA)cert.PrivateKey, doc);
 
                 // Act
@@ -122,8 +122,8 @@ namespace SAML2.Tests
             public void CanDecryptAssertionWithPeerIncludedKeys()
             {
                 // Arrange
-                var doc = AssertionUtil.LoadXmlDocument(@"Assertions\EncryptedAssertion_02");
-                var cert = new X509Certificate2(@"Certificates\sts_dev_certificate.pfx", "test1234");
+                var doc = AssertionUtil.LoadXmlDocument(TestContext.CurrentContext.TestDirectory + @"\Assertions\EncryptedAssertion_02");
+                var cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\sts_dev_certificate.pfx", "test1234");
                 var encryptedAssertion = new Saml20EncryptedAssertion((RSA)cert.PrivateKey, doc);
 
                 // Act
@@ -141,8 +141,8 @@ namespace SAML2.Tests
             public void CanDecryptAssertionWithPeerIncluded3DesKeys()
             {
                 // Arrange
-                var doc = AssertionUtil.LoadXmlDocument(@"Assertions\EncryptedAssertion_04");
-                var cert = new X509Certificate2(@"Certificates\sts_dev_certificate.pfx", "test1234");
+                var doc = AssertionUtil.LoadXmlDocument(TestContext.CurrentContext.TestDirectory + @"\Assertions\EncryptedAssertion_04");
+                var cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\sts_dev_certificate.pfx", "test1234");
                 var encryptedAssertion = new Saml20EncryptedAssertion((RSA)cert.PrivateKey, doc);
 
                 // Act
@@ -161,8 +161,8 @@ namespace SAML2.Tests
             public void CanDecryptAssertionWithPeerIncludedAesKeys()
             {
                 // Arrange
-                var doc = AssertionUtil.LoadXmlDocument(@"Assertions\EncryptedAssertion_05");
-                var cert = new X509Certificate2(@"Certificates\sts_dev_certificate.pfx", "test1234");
+                var doc = AssertionUtil.LoadXmlDocument(TestContext.CurrentContext.TestDirectory + @"\Assertions\EncryptedAssertion_05");
+                var cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\sts_dev_certificate.pfx", "test1234");
                 var encryptedAssertion = new Saml20EncryptedAssertion((RSA)cert.PrivateKey, doc);
 
                 // Act
@@ -182,8 +182,8 @@ namespace SAML2.Tests
             public void CanDecryptAssertionWithPeerIncludedKeysWithoutSpecifiedEncryptionMethod()
             {
                 // Arrange
-                var doc = AssertionUtil.LoadXmlDocument(@"Assertions\EncryptedAssertion_03");
-                var cert = new X509Certificate2(@"Certificates\sts_dev_certificate.pfx", "test1234");
+                var doc = AssertionUtil.LoadXmlDocument(TestContext.CurrentContext.TestDirectory + @"\Assertions\EncryptedAssertion_03");
+                var cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\sts_dev_certificate.pfx", "test1234");
                 var encryptedAssertion = new Saml20EncryptedAssertion((RSA)cert.PrivateKey, doc);
 
                 // Act
@@ -200,20 +200,19 @@ namespace SAML2.Tests
             /// The entire message is Base 64 encoded in this case.
             /// </remarks>
             [Test]
-            [ExpectedException(typeof(Saml20Exception), ExpectedMessage = "Assertion is no longer valid.")]
             public void CanDecryptFOBSAssertion()
             {
                 // Arrange
-                var doc = AssertionUtil.LoadBase64EncodedXmlDocument(@"Assertions\fobs-assertion2");
+                var doc = AssertionUtil.LoadBase64EncodedXmlDocument(TestContext.CurrentContext.TestDirectory + @"\Assertions\fobs-assertion2");
                 var encryptedList = doc.GetElementsByTagName(EncryptedAssertion.ElementName, Saml20Constants.Assertion);
 
                 // Do some mock configuration.
                 var config = Saml2Config.GetConfig();
                 config.AllowedAudienceUris.Add(new AudienceUriElement { Uri = "https://saml.safewhere.net" });
-                config.IdentityProviders.MetadataLocation = @"Protocol\MetadataDocs\FOBS"; // Set it manually.     
-                Assert.That(Directory.Exists(config.IdentityProviders.MetadataLocation));
+                config.IdentityProviders.MetadataLocation = TestContext.CurrentContext.TestDirectory + @"\Protocol\MetadataDocs\FOBS"; // Set it manually.
+                config.IdentityProviders.Refresh();
 
-                var cert = new X509Certificate2(@"Certificates\SafewhereTest_SFS.pfx", "test1234");
+                var cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\SafewhereTest_SFS.pfx", "test1234");
                 var encryptedAssertion = new Saml20EncryptedAssertion((RSA)cert.PrivateKey);
 
                 encryptedAssertion.LoadXml((XmlElement)encryptedList[0]);
@@ -230,18 +229,11 @@ namespace SAML2.Tests
                 Assert.IsNotNull(endp, "Endpoint not found");
                 Assert.IsNotNull(endp.Metadata, "Metadata not found");
 
-                try
-                {
-                    assertion.CheckValid(AssertionUtil.GetTrustedSigners(assertion.Issuer));
-                    Assert.Fail("Verification should fail. Token does not include its signing key.");
-                }
-                catch (InvalidOperationException)
-                {
-                }
+                Assert.Throws<Saml20Exception>(() => assertion.CheckValid(AssertionUtil.GetTrustedSigners(assertion.Issuer)), "Assertion is no longer valid.");
 
-                Assert.IsNull(assertion.SigningKey, "Signing key is already present on assertion. Modify test.");
-                Assert.That(assertion.CheckSignature(Saml20SignonHandler.GetTrustedSigners(endp.Metadata.GetKeys(KeyTypes.Signing), endp)));
-                Assert.IsNotNull(assertion.SigningKey, "Signing key was not set on assertion instance.");
+                //Assert.IsNull(assertion.SigningKey, "Signing key is already present on assertion. Modify test.");
+                //Assert.That(assertion.CheckSignature(Saml20SignonHandler.GetTrustedSigners(endp.Metadata.GetKeys(KeyTypes.Signing), endp)));
+                //Assert.IsNotNull(assertion.SigningKey, "Signing key was not set on assertion instance.");
             }
         }
 
@@ -259,7 +251,7 @@ namespace SAML2.Tests
             {
                 // Arrange
                 var encryptedAssertion = new Saml20EncryptedAssertion { Assertion = AssertionUtil.GetTestAssertion() };
-                var cert = new X509Certificate2(@"Certificates\sts_dev_certificate.pfx", "test1234");
+                var cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\sts_dev_certificate.pfx", "test1234");
                 encryptedAssertion.TransportKey = (RSA)cert.PublicKey.Key;
 
                 // Act
@@ -283,14 +275,10 @@ namespace SAML2.Tests
             /// Verify that exception is thrown on incorrect algorithm URI being passed in.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(ArgumentException))]
             public void ThrowsArgumentExceptionOnIncorrectAlgorithmUri()
             {
                 // Act
-                var encryptedAssertion = new Saml20EncryptedAssertion { SessionKeyAlgorithm = "RSA" };
-
-                // Assert
-                Assert.Fail("\"Saml20EncryptedAssertion\" class does not respond to incorrect algorithm identifying URI.");
+                Assert.Throws<ArgumentException>(() => new Saml20EncryptedAssertion { SessionKeyAlgorithm = "RSA" }, "\"Saml20EncryptedAssertion\" class does not respond to incorrect algorithm identifying URI.");
             }
         }
     }

--- a/src/SAML2.Tests/Saml20MetadataDocumentTests.cs
+++ b/src/SAML2.Tests/Saml20MetadataDocumentTests.cs
@@ -27,7 +27,7 @@ namespace SAML2.Tests
             {
                 // Arrange
                 var doc = new XmlDocument { PreserveWhitespace = true };
-                doc.Load(@"Protocol\MetadataDocs\metadata-ADLER.xml");
+                doc.Load(TestContext.CurrentContext.TestDirectory + @"\Protocol\MetadataDocs\metadata-ADLER.xml");
 
                 // Act
                 var metadata = new Saml20MetadataDocument(doc);
@@ -54,7 +54,7 @@ namespace SAML2.Tests
             {
                 // Arrange
                 var doc = new XmlDocument { PreserveWhitespace = true };
-                doc.Load(@"Protocol\MetadataDocs\metadata-ADLER.xml");
+                doc.Load(TestContext.CurrentContext.TestDirectory + @"\Protocol\MetadataDocs\metadata-ADLER.xml");
 
                 // Act
                 var metadata = new Saml20MetadataDocument(doc);

--- a/src/SAML2.Tests/SignatureTest.cs
+++ b/src/SAML2.Tests/SignatureTest.cs
@@ -21,9 +21,9 @@ namespace SAML2.Tests
         [Test]
         public void VerifyValidSignaturesAreValid()
         {
-            Assert.That(VerifySignature(@"Assertions\Saml2Assertion_01"));
-            Assert.That(VerifySignature(@"Assertions\Saml2Assertion_02"));
-            Assert.That(VerifySignature(@"Assertions\Saml2Assertion_03"));            
+            Assert.That(VerifySignature(TestContext.CurrentContext.TestDirectory + @"\Assertions\Saml2Assertion_01"));
+            Assert.That(VerifySignature(TestContext.CurrentContext.TestDirectory + @"\Assertions\Saml2Assertion_02"));
+            Assert.That(VerifySignature(TestContext.CurrentContext.TestDirectory + @"\Assertions\Saml2Assertion_03"));            
         }
 
         /// <summary>
@@ -32,53 +32,47 @@ namespace SAML2.Tests
         [Test]
         public void VerifyManipulatedSignatureAreInvalid()
         {
-            Assert.IsFalse(VerifySignature(@"Assertions\EvilSaml2Assertion_01"));
-            Assert.IsFalse(VerifySignature(@"Assertions\EvilSaml2Assertion_02"));
-            Assert.IsFalse(VerifySignature(@"Assertions\EvilSaml2Assertion_03"));
+            Assert.IsFalse(VerifySignature(TestContext.CurrentContext.TestDirectory + @"\Assertions\EvilSaml2Assertion_01"));
+            Assert.IsFalse(VerifySignature(TestContext.CurrentContext.TestDirectory + @"\Assertions\EvilSaml2Assertion_02"));
+            Assert.IsFalse(VerifySignature(TestContext.CurrentContext.TestDirectory + @"\Assertions\EvilSaml2Assertion_03"));
         }
 
         /// <summary>
         /// Deserializes the test tokens using the Safewhere DK-SAML class.
         /// </summary>
-        /// <remarks>
-        /// TODO: test data needs fixing
-        /// </remarks>
-        [Ignore]
+        [Ignore("Test data needs fixing")]
         public void TestSaml20TokenVerification01()
         {
-            AssertionUtil.DeserializeToken(@"Assertions\Saml2Assertion_01");
-            AssertionUtil.DeserializeToken(@"Assertions\Saml2Assertion_02");
-            AssertionUtil.DeserializeToken(@"Assertions\Saml2Assertion_03");
+            AssertionUtil.DeserializeToken(TestContext.CurrentContext.TestDirectory + @"\Assertions\Saml2Assertion_01");
+            AssertionUtil.DeserializeToken(TestContext.CurrentContext.TestDirectory + @"\Assertions\Saml2Assertion_02");
+            AssertionUtil.DeserializeToken(TestContext.CurrentContext.TestDirectory + @"\Assertions\Saml2Assertion_03");
         }
 
         /// <summary>
         /// Attempts to deserialize an invalid SAML-token. Tests that the Assertion class immediately "explodes".
         /// </summary>
         [Test]
-        [ExpectedException(typeof(Saml20Exception), ExpectedMessage = "Signature could not be verified.")]
         public void TestSaml20TokenVerification02()
         {
-            AssertionUtil.DeserializeToken(@"Assertions\EvilSaml2Assertion_01");
+            Assert.Throws<Saml20Exception>(() => AssertionUtil.DeserializeToken(TestContext.CurrentContext.TestDirectory + @"\Assertions\EvilSaml2Assertion_01"), "Signature could not be verified.");
         }
 
         /// <summary>
         /// Attempts to deserialize an invalid SAML-token. Tests that the Assertion class immediately "explodes".
         /// </summary>
         [Test]
-        [ExpectedException(typeof(Saml20Exception), ExpectedMessage = "Signature could not be verified.")]
         public void TestSaml20TokenVerification03()
         {
-            AssertionUtil.DeserializeToken(@"Assertions\EvilSaml2Assertion_02");
+            Assert.Throws<Saml20Exception>(() => AssertionUtil.DeserializeToken(TestContext.CurrentContext.TestDirectory + @"\Assertions\EvilSaml2Assertion_02"), "Signature could not be verified.");
         }
 
         /// <summary>
         /// Attempts to deserialize an invalid SAML-token. Tests that the Assertion class immediately "explodes".
         /// </summary>
         [Test]
-        [ExpectedException(typeof(Saml20Exception), ExpectedMessage = "Signature could not be verified.")]
         public void TestSaml20TokenVerification04()
         {
-            AssertionUtil.DeserializeToken(@"Assertions\EvilSaml2Assertion_03");
+            Assert.Throws<Saml20Exception>(() => AssertionUtil.DeserializeToken(TestContext.CurrentContext.TestDirectory + @"\Assertions\EvilSaml2Assertion_03"), "Signature could not be verified.");
         }
 
         #endregion
@@ -129,10 +123,7 @@ namespace SAML2.Tests
         /// Tests the signing code of the Assertion class, by first creating an unsigned assertion and then signing and 
         /// verifying it.
         /// </summary>
-        /// <remarks>
-        /// TODO: test data needs fixing
-        /// </remarks>
-        [Ignore]
+        [Ignore("Test data needs fixing")]
         public void TestSigning03()
         {
             // Load an unsigned assertion. 
@@ -150,7 +141,7 @@ namespace SAML2.Tests
                 Assert.That(true);
             }
 
-            var cert = new X509Certificate2(@"Certificates\sts_dev_certificate.pfx", "test1234");
+            var cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\sts_dev_certificate.pfx", "test1234");
             Assert.That(cert.HasPrivateKey, "Certificate no longer contains a private key. Modify test.");
             assertion.Sign(cert);
 
@@ -201,7 +192,7 @@ namespace SAML2.Tests
             //    signedXml.KeyInfo.AddClause(new RSAKeyValue(rsaKey));
 
             // Use X509 Certificate for signing.
-            var cert = new X509Certificate2(@"Certificates\sts_dev_certificate.pfx", "test1234");
+            var cert = new X509Certificate2(TestContext.CurrentContext.TestDirectory + @"\Certificates\sts_dev_certificate.pfx", "test1234");
             Assert.That(cert.HasPrivateKey);
             signedXml.SigningKey = cert.PrivateKey;
             signedXml.KeyInfo.AddClause(new KeyInfoX509Data(cert, X509IncludeOption.EndCertOnly));

--- a/src/SAML2.Tests/Utils/ArtifactUtilTests.cs
+++ b/src/SAML2.Tests/Utils/ArtifactUtilTests.cs
@@ -67,7 +67,6 @@ namespace SAML2.Tests.Utils
             /// Verify exception is thrown on message handle length mismatch.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(ArgumentException))]
             public void ThrowsExceptionWhenMessageHandleLengthMismatch()
             {
                 // Arrange
@@ -77,14 +76,13 @@ namespace SAML2.Tests.Utils
                 var messageHandle = new byte[19];
 
                 // Act
-                ArtifactUtil.CreateArtifact(typeCode, endpointIndex, sourceIdHash, messageHandle);
+                Assert.Throws<ArgumentException>(() => ArtifactUtil.CreateArtifact(typeCode, endpointIndex, sourceIdHash, messageHandle));
             }
 
             /// <summary>
             /// Verify exception is thrown on source id hash length mismatch.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(ArgumentException))]
             public void ThrowsExceptionWhenSourceIdHashLengthMismatch()
             {
                 // Arrange
@@ -94,7 +92,7 @@ namespace SAML2.Tests.Utils
                 var messageHandle = new byte[20];
 
                 // Act
-                ArtifactUtil.CreateArtifact(typeCode, endpointIndex, sourceIdHash, messageHandle);
+                Assert.Throws<ArgumentException>(() => ArtifactUtil.CreateArtifact(typeCode, endpointIndex, sourceIdHash, messageHandle));
             }
         }
 
@@ -108,7 +106,6 @@ namespace SAML2.Tests.Utils
             /// Verify exception is thrown on source id hash length mismatch.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(ArgumentException))]
             public void ThrowsExceptionWhenSourceIdHashLengthMismatch()
             {
                 // Arrange
@@ -119,14 +116,13 @@ namespace SAML2.Tests.Utils
                 var artifact = string.Empty;
 
                 // Act
-                ArtifactUtil.ParseArtifact(artifact, ref parsedTypeCode, ref parsedEndpointIndex, ref parsedSourceIdHash, ref parsedMessageHandle);
+                Assert.Throws<ArgumentException>(() => ArtifactUtil.ParseArtifact(artifact, ref parsedTypeCode, ref parsedEndpointIndex, ref parsedSourceIdHash, ref parsedMessageHandle));
             }
 
             /// <summary>
             /// Verify exception is thrown on message handle length mismatch.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(ArgumentException))]
             public void ThrowsExceptionWhenMessageHandleLengthMismatch()
             {
                 // Arrange
@@ -137,14 +133,13 @@ namespace SAML2.Tests.Utils
                 var artifact = string.Empty;
 
                 // Act
-                ArtifactUtil.ParseArtifact(artifact, ref parsedTypeCode, ref parsedEndpointIndex, ref parsedSourceIdHash, ref parsedMessageHandle);
+                Assert.Throws<ArgumentException>(() => ArtifactUtil.ParseArtifact(artifact, ref parsedTypeCode, ref parsedEndpointIndex, ref parsedSourceIdHash, ref parsedMessageHandle));
             }
 
             /// <summary>
             /// Verify exception is thrown on artifact length mismatch.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(ArgumentException))]
             public void ThrowsExceptionWhenArtifactLengthMismatch()
             {
                 // Arrange
@@ -155,7 +150,7 @@ namespace SAML2.Tests.Utils
                 var artifact = string.Empty;
 
                 // Act
-                ArtifactUtil.ParseArtifact(artifact, ref parsedTypeCode, ref parsedEndpointIndex, ref parsedSourceIdHash, ref parsedMessageHandle);
+                Assert.Throws<ArgumentException>(() => ArtifactUtil.ParseArtifact(artifact, ref parsedTypeCode, ref parsedEndpointIndex, ref parsedSourceIdHash, ref parsedMessageHandle));
             }
         }
 

--- a/src/SAML2.Tests/Utils/Saml20UtilsTests.cs
+++ b/src/SAML2.Tests/Utils/Saml20UtilsTests.cs
@@ -37,17 +37,13 @@ namespace SAML2.Tests.Utils
             /// Verify <see cref="Saml20FormatException"/> is thrown on failure.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException))]
             public void ThrowsSaml20FormatExceptionOnFailure()
             {
                 // Arrange
                 var localtime = DateTime.UtcNow.ToString();
 
                 // Act
-                Saml20Utils.FromUtcString(localtime);
-
-                // Assert
-                Assert.Fail("Conversion from non-UTC string must not succeed");
+                Assert.Throws<Saml20FormatException>(() => Saml20Utils.FromUtcString(localtime));
             }
         }
 

--- a/src/SAML2.Tests/Utils/XmlSignatureUtilsTest.cs
+++ b/src/SAML2.Tests/Utils/XmlSignatureUtilsTest.cs
@@ -42,7 +42,7 @@ namespace SAML2.Tests.Utils
             public void CanCheckValidSignatures()
             {
                 // Arrange
-                var doc = LoadDocument(@"Assertions\Saml2Assertion_01");
+                var doc = LoadDocument(TestContext.CurrentContext.TestDirectory + @"\Assertions\Saml2Assertion_01");
 
                 // Act
                 var result = XmlSignatureUtils.CheckSignature(doc);
@@ -65,7 +65,7 @@ namespace SAML2.Tests.Utils
             public void CanExtractKeyInfo()
             {
                 // Arrange
-                var doc = LoadDocument(@"Assertions\Saml2Assertion_01");
+                var doc = LoadDocument(TestContext.CurrentContext.TestDirectory + @"\Assertions\Saml2Assertion_01");
 
                 // Act
                 var keyInfo = XmlSignatureUtils.ExtractSignatureKeys(doc);
@@ -88,8 +88,8 @@ namespace SAML2.Tests.Utils
             public void CanDetectIfDocumentIsSigned()
             {
                 // Arrange
-                var badDocument = LoadDocument(@"Assertions\EncryptedAssertion_01");
-                var goodDocument = LoadDocument(@"Assertions\Saml2Assertion_01");
+                var badDocument = LoadDocument(TestContext.CurrentContext.TestDirectory + @"\Assertions\EncryptedAssertion_01");
+                var goodDocument = LoadDocument(TestContext.CurrentContext.TestDirectory + @"\Assertions\Saml2Assertion_01");
 
                 // Act
                 var badResult = XmlSignatureUtils.IsSigned(badDocument);
@@ -104,18 +104,14 @@ namespace SAML2.Tests.Utils
             /// Verify documents without preserve whitespace set will fail.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(InvalidOperationException))]
             public void FailsOnDocumentWithoutPreserveWhitespace()
             {
                 // Arrange
-                var doc = LoadDocument(@"Assertions\EncryptedAssertion_01");
+                var doc = LoadDocument(TestContext.CurrentContext.TestDirectory + @"\Assertions\EncryptedAssertion_01");
                 doc.PreserveWhitespace = false;
 
                 // Act
-                XmlSignatureUtils.IsSigned(doc);
-
-                // Assert
-                Assert.Fail("Signed documents that do not have PreserveWhitespace set should fail to be processed.");
+                Assert.Throws<InvalidOperationException>(() => XmlSignatureUtils.IsSigned(doc));
             }
         }
     }

--- a/src/SAML2.Tests/Validation/Saml20AssertionValidatorTests.cs
+++ b/src/SAML2.Tests/Validation/Saml20AssertionValidatorTests.cs
@@ -22,7 +22,6 @@ namespace SAML2.Tests.Validation
             /// Tests validation of missing ID attribute
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Assertion element must have the ID attribute set.")]
             public void ThrowsExceptionWhenIdNull()
             {
                 // Arrange
@@ -32,14 +31,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20AssertionValidator(AssertionUtil.GetAudiences(), false);
 
                 // Act
-                validator.ValidateAssertion(assertion);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateAssertion(assertion), "Assertion element must have the ID attribute set.");
             }
 
             /// <summary>
             /// Tests validation of Issuer Element format
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID element has Format attribute which is not a wellformed absolute uri.")]
             public void ThrowsExceptionWhenIssuerFormatInvalid()
             {
                 // Arrange
@@ -49,14 +47,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20AssertionValidator(AssertionUtil.GetAudiences(), false);
 
                 // Act
-                validator.ValidateAssertion(assertion);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateAssertion(assertion), "NameID element has Format attribute which is not a wellformed absolute uri.");
             }
 
             /// <summary>
             /// Tests validation of required IssueInstant Element 
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Assertion element must have the IssueInstant attribute set.")]
             public void ThrowsExceptionWhenIssueInstantNull()
             {
                 // Arrange
@@ -66,14 +63,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20AssertionValidator(AssertionUtil.GetAudiences(), false);
 
                 // Act
-                validator.ValidateAssertion(assertion);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateAssertion(assertion), "Assertion element must have the IssueInstant attribute set.");
             }
 
             /// <summary>
             /// Tests validation of Issuer Element presence
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Assertion element must have an issuer element.")]
             public void ThrowsExceptionWhenIssuerNull()
             {
                 // Arrange
@@ -83,14 +79,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20AssertionValidator(AssertionUtil.GetAudiences(), false);
 
                 // Act
-                validator.ValidateAssertion(assertion);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateAssertion(assertion), "Assertion element must have an issuer element.");
             }
 
             /// <summary>
             /// Tests validation of wrong version attribute
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Wrong value of version attribute on Assertion element")]
             public void ThrowsExceptionWhenWrongVersion()
             {
                 // Arrange
@@ -100,7 +95,7 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20AssertionValidator(AssertionUtil.GetAudiences(), false);
 
                 // Act
-                validator.ValidateAssertion(assertion);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateAssertion(assertion), "Wrong value of version attribute on Assertion element");
             }
 
             /// <summary>
@@ -128,7 +123,6 @@ namespace SAML2.Tests.Validation
             /// Test that audience-restricted assertions are not valid if ANY of the audience restrictions is not met 
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "The service is not configured to meet the given audience restrictions")]
             public void ThrowsExceptionWhenAudienceRestrictionAnyAudienceRestrictionIsNotMet()
             {
                 // Arrange
@@ -145,14 +139,13 @@ namespace SAML2.Tests.Validation
                 assertion.Conditions.Items = audienceConditions;
 
                 // Act
-                validator.ValidateAssertion(assertion);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateAssertion(assertion), "The service is not configured to meet the given audience restrictions");
             }
 
             /// <summary>
             /// Test that audience-restricted assertions are not valid if the restriction values are incorrectly formatted
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Audience element has value which is not a wellformed absolute uri")]
             public void ThrowsExceptionWhenAudienceRestrictionAudienceFormatIsInvalid()
             {
                 // Arrange
@@ -167,7 +160,7 @@ namespace SAML2.Tests.Validation
                 assertion.Conditions.Items = new List<ConditionAbstract>(new ConditionAbstract[] { audienceRestriction });
 
                 // Act
-                validator.ValidateAssertion(assertion);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateAssertion(assertion), "Audience element has value which is not a wellformed absolute uri");
             }
 
             /// <summary>
@@ -175,7 +168,6 @@ namespace SAML2.Tests.Validation
             /// consider audience-restricted assertions valid
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "The service is not configured to meet the given audience restrictions")]
             public void ThrowsExceptionWhenAudienceRestrictionDoesNotMatch()
             {
                 // Arrange
@@ -187,7 +179,7 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20AssertionValidator(allowedAudienceUris, false);
 
                 // Act
-                validator.ValidateAssertion(assertion);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateAssertion(assertion), "The service is not configured to meet the given audience restrictions");
             }
 
             /// <summary>
@@ -195,7 +187,6 @@ namespace SAML2.Tests.Validation
             /// consider audience-restricted assertions valid
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "The service is not configured to meet any audience restrictions")]
             public void ThrowsExceptionWhenAudienceRestrictionIsNotConfigured()
             {
                 // Arrange
@@ -203,14 +194,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20AssertionValidator(null, false);
 
                 // Act
-                validator.ValidateAssertion(assertion);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateAssertion(assertion), "The service is not configured to meet any audience restrictions");
             }
 
             /// <summary>
             /// Tests the validation that ensures the Count property to be a non-negative integer
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Count attribute of ProxyRestriction MUST BE a non-negative integer")]
             public void ThrowsExceptionWhenProxyRestrictionCountIsNegative()
             {
                 // Arrange
@@ -225,14 +215,13 @@ namespace SAML2.Tests.Validation
                 assertion.Conditions.Items = conditions;
 
                 // Act
-                validator.ValidateAssertion(assertion);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateAssertion(assertion), "Count attribute of ProxyRestriction MUST BE a non-negative integer");
             }
 
             /// <summary>
             /// Tests the validation that ensures the Count property to be a non-negative integer
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "ProxyRestriction Audience MUST BE a wellformed uri")]
             public void ThrowsExceptionWhenProxyRestrictionAudienceIsInvalid()
             {
                 // Arrange
@@ -250,14 +239,13 @@ namespace SAML2.Tests.Validation
                 assertion.Conditions.Items = conditions;
 
                 // Act
-                validator.ValidateAssertion(assertion);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateAssertion(assertion), "ProxyRestriction Audience MUST BE a wellformed uri");
             }
 
             /// <summary>
             /// Tests the validation that ensures at most 1 OneTimeUse condition
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Assertion contained more than one condition of type OneTimeUse")]
             public void ThrowsExceptionWhenThereAreMultipleOneTimeUse()
             {
                 // Arrange
@@ -273,14 +261,13 @@ namespace SAML2.Tests.Validation
                 assertion.Conditions.Items = conditions;
 
                 // Act
-                validator.ValidateAssertion(assertion);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateAssertion(assertion), "Assertion contained more than one condition of type OneTimeUse");
             }
 
             /// <summary>
             /// Tests the validation that ensures at most 1 ProxyRestriction condition
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Assertion contained more than one condition of type ProxyRestriction")]
             public void ThrowsExceptionWhenThereAreMultipleProxyRestriction()
             {
                 // Arrange
@@ -296,7 +283,7 @@ namespace SAML2.Tests.Validation
                 assertion.Conditions.Items = conditions;
 
                 // Act
-                validator.ValidateAssertion(assertion);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateAssertion(assertion), "Assertion contained more than one condition of type ProxyRestriction");
             }
             
             /// <summary>
@@ -405,12 +392,8 @@ namespace SAML2.Tests.Validation
             /// <summary>
             /// Tests that <c>AuthnStatement</c> objects must have a SessionNotOnOrAfter attribute set in the future.
             /// </summary>
-            /// <remarks>
-            /// TODO: test data needs fixing
-            /// </remarks>
             [Test]
-            [Ignore]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "AuthnStatement attribute SessionNotOnOrAfter MUST be in the future")]
+            [Ignore("Test data needs fixing")]
             public void ThrowsExceptionWhenAuthnStatementSessionNotOnOrAfterInPast()
             {
                 // Arrange
@@ -427,14 +410,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20AssertionValidator(AssertionUtil.GetAudiences(), false);
 
                 // Act
-                validator.ValidateTimeRestrictions(assertion, new TimeSpan());
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateTimeRestrictions(assertion, new TimeSpan()), "AuthnStatement attribute SessionNotOnOrAfter MUST be in the future");
             }
 
             /// <summary>
             /// Test validity of assertion when condition has an invalid NotOnOrAfter time restriction
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Conditions.NotOnOrAfter must not be in the past")]
             public void ThrowsExceptionWhenTimeRestrictionNotOnOrAfterNow()
             {
                 // Arrange
@@ -446,7 +428,7 @@ namespace SAML2.Tests.Validation
                 assertion.Conditions.NotOnOrAfter = DateTime.UtcNow;
 
                 // Act
-                validator.ValidateTimeRestrictions(assertion, new TimeSpan());
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateTimeRestrictions(assertion, new TimeSpan()), "Conditions.NotOnOrAfter must not be in the past");
             }
         }
 
@@ -460,7 +442,6 @@ namespace SAML2.Tests.Validation
             /// Test validity of assertion when condition has an invalid NotBefore time restriction
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Conditions.NotBefore must not be in the future")]
             public void ThrowsExceptionWhenTimeRestrictionNotBeforeIsInvalid()
             {
                 // Arrange
@@ -472,14 +453,13 @@ namespace SAML2.Tests.Validation
                 assertion.Conditions.NotOnOrAfter = null;
 
                 // Act
-                validator.ValidateTimeRestrictions(assertion, new TimeSpan());
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateTimeRestrictions(assertion, new TimeSpan()), "Conditions.NotBefore must not be in the future");
             }
 
             /// <summary>
             /// Test validity of assertion when condition has an invalid NotOnOrAfter time restriction
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Conditions.NotOnOrAfter must not be in the past")]
             public void ThrowsExceptionWhenTimeRestrictionNotOnOrAfterYesterday()
             {
                 // Arrange
@@ -491,7 +471,7 @@ namespace SAML2.Tests.Validation
                 assertion.Conditions.NotOnOrAfter = DateTime.UtcNow.AddDays(-1);
 
                 // Act
-                validator.ValidateTimeRestrictions(assertion, new TimeSpan());
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateTimeRestrictions(assertion, new TimeSpan()), "Conditions.NotOnOrAfter must not be in the past");
             }
 
             /// <summary>

--- a/src/SAML2.Tests/Validation/Saml20NameIdValidatorTests.cs
+++ b/src/SAML2.Tests/Validation/Saml20NameIdValidatorTests.cs
@@ -75,7 +75,6 @@ namespace SAML2.Tests.Validation
             /// Verify exception is thrown on Email Value containing only whitespace characters.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Email Format attribute MUST contain a Value that contains more than whitespace characters")]
             public void ThrowsExceptionWhenEmailValueContainsOnlyWhitespace()
             {
                 // Arrange
@@ -87,7 +86,7 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Email Format attribute MUST contain a Value that contains more than whitespace characters");
             }
 
             /// <summary>
@@ -116,7 +115,6 @@ namespace SAML2.Tests.Validation
             /// Verify exception is thrown on X509SubjectName Value containing only whitespace characters.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with X509SubjectName Format attribute MUST contain a Value that contains more than whitespace characters")]
             public void ThrowsExceptionWhenX509SubjecNameValueContainsOnlyWhirespace()
             {
                 // Arrange
@@ -128,14 +126,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with X509SubjectName Format attribute MUST contain a Value that contains more than whitespace characters");
             }
 
             /// <summary>
             /// Verify exception is thrown on X509SubjectName Value being empty.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with X509SubjectName Format attribute MUST contain a Value that contains more than whitespace characters")]
             public void ThrowsExceptionWhenX509SubjecNameValueEmpty()
             {
                 // Arrange
@@ -147,7 +144,7 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with X509SubjectName Format attribute MUST contain a Value that contains more than whitespace characters");
             }
 
             #endregion
@@ -158,7 +155,6 @@ namespace SAML2.Tests.Validation
             /// Verify exception is thrown on WindowsDomainQualifiedName Value containing only whitespace characters.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Windows Format attribute MUST contain a Value that contains more than whitespace characters")]
             public void ThrowsExceptionWhenWindowsDomainQualifiedNameValueContainsOnlyWhitespace()
             {
                 // Arrange
@@ -170,7 +166,7 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Windows Format attribute MUST contain a Value that contains more than whitespace characters");
             }
 
             /// <summary>
@@ -202,7 +198,6 @@ namespace SAML2.Tests.Validation
             /// Verify exception is thrown on Kerberos Value containing only whitespace characters.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Kerberos Format attribute MUST contain a Value that contains more than whitespace characters")]
             public void ThrowsExceptionWhenKerberosValueContainsOnlyWhitespace()
             {
                 // Arrange
@@ -214,14 +209,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Kerberos Format attribute MUST contain a Value that contains more than whitespace characters");
             }
 
             /// <summary>
             /// Verify exception is thrown on Kerberos Value being empty.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Kerberos Format attribute MUST contain a Value that contains more than whitespace characters")]
             public void ThrowsExceptionWhenKerberosValueEmpty()
             {
                 // Arrange
@@ -233,14 +227,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Kerberos Format attribute MUST contain a Value that contains more than whitespace characters");
             }
 
             /// <summary>
             /// Verify exception is thrown on kerberos invalid format.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Kerberos Format attribute MUST contain a Value that contains a '@'")]
             public void ThrowsExceptionWhenKerberosInvalidFormat()
             {
                 // Arrange
@@ -252,14 +245,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Kerberos Format attribute MUST contain a Value that contains a '@'");
             }
 
             /// <summary>
             /// Verify exception is thrown on Kerberos Value with length less than three characters.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Kerberos Format attribute MUST contain a Value with at least 3 characters")]
             public void ThrowsExceptionWhenKerberosLessThanThreecharacters()
             {
                 // Arrange
@@ -271,7 +263,7 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Kerberos Format attribute MUST contain a Value with at least 3 characters");
             }
 
             /// <summary>
@@ -300,7 +292,6 @@ namespace SAML2.Tests.Validation
             /// Verify exception is thrown on Entity Value containing only whitespace characters.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Entity Format attribute MUST contain a Value that contains more than whitespace characters")]
             public void ThrowsExceptionWhenEntityValueContainsOnlyWhitespace()
             {
                 // Arrange
@@ -312,14 +303,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Entity Format attribute MUST contain a Value that contains more than whitespace characters");
             }
 
             /// <summary>
             /// Verify exception is thrown on Entity Value being empty.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Entity Format attribute MUST contain a Value that contains more than whitespace characters")]
             public void ThrowsExceptionWhenEntityValueEmpty()
             {
                 // Arrange
@@ -331,14 +321,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Entity Format attribute MUST contain a Value that contains more than whitespace characters");
             }
 
             /// <summary>
             /// Verify exception is thrown on Entity Value length being too long.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Entity Format attribute MUST have a Value that contains no more than 1024 characters")]
             public void ThrowsExceptionWhenEntityLengthTooLong()
             {
                 // Arrange
@@ -350,14 +339,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Entity Format attribute MUST have a Value that contains no more than 1024 characters");
             }
 
             /// <summary>
             /// Verify exception is thrown on Entity with NameQualifier set.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Entity Format attribute MUST NOT set the NameQualifier attribute")]
             public void ThrowsExceptionWhenEntityNameQualifierSet()
             {
                 // Arrange
@@ -370,14 +358,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Entity Format attribute MUST NOT set the NameQualifier attribute");
             }
 
             /// <summary>
             /// Verify exception is thrown on Entity SPNameQualifier set.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Entity Format attribute MUST NOT set the SPNameQualifier attribute")]
             public void ThrowsExceptionWhenEntitySPNameQualifierSet()
             {
                 // Arrange
@@ -390,14 +377,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Entity Format attribute MUST NOT set the SPNameQualifier attribute");
             }
 
             /// <summary>
             /// Verify exception is thrown on Entity SPProvidedID set.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Entity Format attribute MUST NOT set the SPProvidedID attribute")]
             public void ThrowsExceptionWhenEntitySPProvidedId()
             {
                 // Arrange
@@ -410,7 +396,7 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Entity Format attribute MUST NOT set the SPProvidedID attribute");
             }
 
             /// <summary>
@@ -439,7 +425,6 @@ namespace SAML2.Tests.Validation
             /// Verify exception is thrown on Persistent Value containing only whitespace characters.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Persistent Format attribute MUST contain a Value that contains more than whitespace characters")]
             public void ThrowsExceptionWhenPersistentContainsOnlyWhitespace()
             {
                 // Arrange
@@ -451,14 +436,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Persistent Format attribute MUST contain a Value that contains more than whitespace characters");
             }
 
             /// <summary>
             /// Verify exception is thrown on Persistent Value being empty.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Persistent Format attribute MUST contain a Value that contains more than whitespace characters")]
             public void ThrowsExceptionWhenPersistentValueEmpty()
             {
                 // Arrange
@@ -470,14 +454,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Persistent Format attribute MUST contain a Value that contains more than whitespace characters");
             }
 
             /// <summary>
             /// Verify exception is thrown on Persistent Value length being too long.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Persistent Format attribute MUST have a Value that contains no more than 256 characters")]
             public void ThrowsExceptionWhenPersistentLengthTooLong()
             {
                 // Arrange
@@ -489,7 +472,7 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Persistent Format attribute MUST have a Value that contains no more than 256 characters");
             }
 
             /// <summary>
@@ -515,7 +498,6 @@ namespace SAML2.Tests.Validation
             /// Verify exception is thrown on Transient Value length being too long.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Transient Format attribute MUST have a Value that contains no more than 256 characters")]
             public void ThrowsExceptionWhenTransientValueTooLong()
             {
                 // Arrange
@@ -527,14 +509,13 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Transient Format attribute MUST have a Value that contains no more than 256 characters");
             }
 
             /// <summary>
             /// Verify exception is thrown on Transient Value being too short.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NameID with Transient Format attribute MUST have a Value with at least 16 characters (the equivalent of 128 bits)")]
             public void ThrowsExceptionWhenTransientValueTooShort()
             {
                 // Arrange
@@ -546,9 +527,9 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20NameIdValidator();
 
                 // Act
-                validator.ValidateNameId(nameId);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateNameId(nameId), "NameID with Transient Format attribute MUST have a Value with at least 16 characters (the equivalent of 128 bits)");
             }
-            
+
             /// <summary>
             /// Verify validates transient.
             /// </summary>

--- a/src/SAML2.Tests/Validation/Saml20StatementValidatorTests.cs
+++ b/src/SAML2.Tests/Validation/Saml20StatementValidatorTests.cs
@@ -22,7 +22,6 @@ namespace SAML2.Tests.Validation
             /// Verify exception is thrown on AttributeStatement Attribute list being null.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "AttributeStatement MUST contain at least one Attribute or EncryptedAttribute")]
             public void ThrowsExceptionWhenNullAttributeList()
             {
                 // Arrange
@@ -32,14 +31,14 @@ namespace SAML2.Tests.Validation
                 statement.Items = null;
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "AttributeStatement MUST contain at least one Attribute or EncryptedAttribute");
             }
 
             /// <summary>
             /// Verify exception is thrown on AttributeStatement containing no Attributes or EncryptedAttributes.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "AttributeStatement MUST contain at least one Attribute or EncryptedAttribute")]
             public void ThrowsExceptionWhenEmptyAttributeList()
             {
                 // Arrange
@@ -49,14 +48,14 @@ namespace SAML2.Tests.Validation
                 statement.Items = new object[0];
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "AttributeStatement MUST contain at least one Attribute or EncryptedAttribute");
             }
 
             /// <summary>
             /// Verify that Attribute objects must have a non-empty Name
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Name attribute of Attribute element MUST contain at least one non-whitespace character")]
             public void ThrowsExceptionWhenAttributeElementEmptyName()
             {
                 // Arrange
@@ -66,7 +65,8 @@ namespace SAML2.Tests.Validation
                 statement.Items = new object[] { new SamlAttribute() };
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "Name attribute of Attribute element MUST contain at least one non-whitespace character");
             }
         }
 
@@ -80,7 +80,6 @@ namespace SAML2.Tests.Validation
             /// Tests that <c>AuthnStatement</c> objects must have an valid uri content for <c>AuthenticatingAuthority</c> entries
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "AuthenticatingAuthority array contains a value which is not a wellformed absolute uri")]
             public void ThrowsExceptionWhenAuthnContextAuthenticatingAuthorityUriInvalid()
             {
                 // Arrange
@@ -90,66 +89,66 @@ namespace SAML2.Tests.Validation
                                         SessionNotOnOrAfter = DateTime.UtcNow.AddHours(1)
                                     };
                 statement.AuthnContext = new AuthnContext
-                                             {
-                                                 AuthenticatingAuthority = new[]
-                                                                               {
-                                                                                   "urn:aksdlfj",
-                                                                                   "urn/invalid"
-                                                                               },
-                                                 Items = new object[]
-                                                             {
-                                                                 "urn:a:valid.uri:string",
-                                                                 "http://another/valid/uri.string"
-                                                             },
-                                                 ItemsElementName = new[]
-                                                                        {
-                                                                            AuthnContextType.AuthnContextClassRef,
-                                                                            AuthnContextType.AuthnContextDeclRef
-                                                                        }
-                                             };
+                {
+                    AuthenticatingAuthority = new[]
+                    {
+                        "urn:aksdlfj",
+                        "urn/invalid"
+                    },
+                    Items = new object[]
+                    {
+                        "urn:a:valid.uri:string",
+                        "http://another/valid/uri.string"
+                    },
+                    ItemsElementName = new[]
+                    {
+                        AuthnContextType.AuthnContextClassRef,
+                        AuthnContextType.AuthnContextDeclRef
+                    }
+                };
                 var validator = new Saml20StatementValidator();
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "AuthenticatingAuthority array contains a value which is not a wellformed absolute uri");
             }
 
             /// <summary>
             /// Tests that <c>AuthnStatement</c> objects must have a valid uri content for <c>AuthnContextClassRef</c> types
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "AuthnContextClassRef has a value which is not a wellformed absolute uri")]
             public void ThrowsExceptionWhenAuthnContextAuthnContextClassRefUriInvalid()
             {
                 // Arrange
                 var statement = new AuthnStatement
-                                    {
-                                        AuthnInstant = DateTime.UtcNow,
-                                        SessionNotOnOrAfter = DateTime.UtcNow.AddHours(1)
-                                    };
+                {
+                    AuthnInstant = DateTime.UtcNow,
+                    SessionNotOnOrAfter = DateTime.UtcNow.AddHours(1)
+                };
                 statement.AuthnContext = new AuthnContext
-                                             {
-                                                 Items = new object[]
-                                                             {
-                                                                 string.Empty,
-                                                                 "urn:a.valid.uri:string"
-                                                             },
-                                                 ItemsElementName = new[]
-                                                                        {
-                                                                            AuthnContextType.AuthnContextClassRef,
-                                                                            AuthnContextType.AuthnContextDeclRef
-                                                                        }
-                                             };
+                {
+                    Items = new object[]
+                    {
+                        string.Empty,
+                        "urn:a.valid.uri:string"
+                    },
+                    ItemsElementName = new[]
+                    {
+                        AuthnContextType.AuthnContextClassRef,
+                        AuthnContextType.AuthnContextDeclRef
+                    }
+                };
                 var validator = new Saml20StatementValidator();
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "AuthnContextClassRef has a value which is not a wellformed absolute uri");
             }
 
             /// <summary>
             /// Tests that <c>AuthnStatement</c> objects MUST NOT have content of type <c>AuthnContextDecl</c>
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "AuthnContextDecl elements are not allowed in this implementation")]
             public void ThrowsExceptionWhenAuthnContextAuthnContextDeclInvalid()
             {
                 // Arrange
@@ -172,14 +171,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20StatementValidator();
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "AuthnContextDecl elements are not allowed in this implementation");
             }
 
             /// <summary>
             /// Tests that <c>AuthnStatement</c> objects must have a valid uri content for <c>AuthnContextDeclRef</c> types
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "AuthnContextDeclRef has a value which is not a wellformed absolute uri")]
             public void ThrowsExceptionWhenAuthnContextAuthnContextDeclRefUriInvalid()
             {
                 // Arrange
@@ -204,14 +203,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20StatementValidator();
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "AuthnContextDeclRef has a value which is not a wellformed absolute uri");
             }
 
             /// <summary>
             /// Tests that <c>AuthnStatement</c> objects must have a <c>AuthnContextClassRef</c> type as the first element if it is present
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "AuthnContextClassRef must be in the first element")]
             public void ThrowsExceptionWhenAuthnContextFirstItemNotAuthnContextClassRef()
             {
                 // Arrange
@@ -236,14 +235,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20StatementValidator();
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "AuthnContextClassRef must be in the first element");
             }
 
             /// <summary>
             /// Tests that <c>AuthnStatement</c> objects must have no more than 2 {<c>AuthnContextClassRef</c>, <c>AuthnContextDeclRef</c>} elements
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "AuthnContext MUST NOT contain more than two elements.")]
             public void ThrowsExceptionWhenAuthnContextHasMoreThanTwoItems()
             {
                 // Arrange
@@ -270,14 +269,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20StatementValidator();
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "AuthnContext MUST NOT contain more than two elements.");
             }
 
             /// <summary>
             /// Tests that <c>AuthnStatement</c> objects must have non-null contents
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "AuthnContext element MUST contain at least one AuthnContextClassRef, AuthnContextDecl or AuthnContextDeclRef element")]
             public void ThrowsExceptionWhenAuthnContextItemsEmpty()
             {
                 // Arrange
@@ -294,14 +293,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20StatementValidator();
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "AuthnContext element MUST contain at least one AuthnContextClassRef, AuthnContextDecl or AuthnContextDeclRef element");
             }
 
             /// <summary>
             /// Tests that <c>AuthnStatement</c> objects must have non-empty contents
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "AuthnContext element MUST contain at least one AuthnContextClassRef, AuthnContextDecl or AuthnContextDeclRef element")]
             public void ThrowsExceptionWhenAuthnContextItemsNull()
             {
                 // Arrange
@@ -314,14 +313,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20StatementValidator();
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "AuthnContext element MUST contain at least one AuthnContextClassRef, AuthnContextDecl or AuthnContextDeclRef element");
             }
 
             /// <summary>
             /// Tests that <c>AuthnStatement</c> objects must have an <c>AuthnContext</c> element
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "AuthnStatement MUST have an AuthnContext element")]
             public void ThrowsExceptionWhenAuthnContextNull()
             {
                 // Arrange
@@ -333,14 +332,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20StatementValidator();
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "AuthnStatement MUST have an AuthnContext element");
             }
 
             /// <summary>
             /// Tests that <c>AuthnStatement</c> objects must have an <c>AuthnInstant</c> attribute.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "AuthnStatement MUST have an AuthnInstant attribute")]
             public void ThrowsExceptionWhenAuthnInstantNull()
             {
                 // Arrange
@@ -350,7 +349,8 @@ namespace SAML2.Tests.Validation
                 statement.AuthnInstant = null;
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "AuthnStatement MUST have an AuthnInstant attribute");
             }
         }
 
@@ -364,7 +364,6 @@ namespace SAML2.Tests.Validation
             /// Verify exception is thrown on malformed resource URI.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Resource attribute of AuthzDecisionStatement has a value which is not a wellformed absolute uri")]
             public void ThrowsExceptionWhenMalformedResource()
             {
                 // Arrange
@@ -374,14 +373,14 @@ namespace SAML2.Tests.Validation
                 statement.Resource = "a malformed uri";
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "Resource attribute of AuthzDecisionStatement has a value which is not a wellformed absolute uri");
             }
 
             /// <summary>
             /// Verify exception is thrown on missing <c>AuthzDecisionStatement</c>.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Resource attribute of AuthzDecisionStatement is REQUIRED")]
             public void ThrowsExceptionWhenMissingResourceEmpty()
             {
                 // Arrange
@@ -391,7 +390,8 @@ namespace SAML2.Tests.Validation
                 statement.Resource = null;
 
                 // Act
-                validator.ValidateStatement(statement);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateStatement(statement),
+                    "Resource attribute of AuthzDecisionStatement is REQUIRED");
             }
 
             /// <summary>

--- a/src/SAML2.Tests/Validation/Saml20SubjectConfirmationDataValidatorTests.cs
+++ b/src/SAML2.Tests/Validation/Saml20SubjectConfirmationDataValidatorTests.cs
@@ -23,7 +23,6 @@ namespace SAML2.Tests.Validation
             /// Verify exception is thrown when key info confirmation data has no any elements.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "SubjectConfirmationData element MUST have at least one " + KeyInfo.ElementName + " subelement")]
             public void ThrowsExceptionWhenKeyInfoConfirmationDataHasNoElements()
             {
                 // Arrange
@@ -31,14 +30,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20SubjectConfirmationDataValidator();
 
                 // Act
-                validator.ValidateSubjectConfirmationData(subjectConfirmationData);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateSubjectConfirmationData(subjectConfirmationData),
+                    "SubjectConfirmationData element MUST have at least one " + KeyInfo.ElementName + " subelement");
             }
 
             /// <summary>
             /// Verify exception is thrown when key info confirmation data has no elements with correct namespace.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "SubjectConfirmationData element MUST contain at least one " + KeyInfo.ElementName + " in namespace " + Saml20Constants.Xmldsig)]
             public void ThrowsExceptionWhenKeyInfoConfirmationDataHasNoElementsWithCorrectNamespace()
             {
                 // Arrange
@@ -50,14 +49,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20SubjectConfirmationDataValidator();
 
                 // Act
-                validator.ValidateSubjectConfirmationData(subjectConfirmationData);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateSubjectConfirmationData(subjectConfirmationData),
+                    "SubjectConfirmationData element MUST contain at least one " + KeyInfo.ElementName + " in namespace " + Saml20Constants.Xmldsig);
             }
 
             /// <summary>
             /// Verify exception is thrown when key info confirmation data has no elements with valid key.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "SubjectConfirmationData element MUST contain at least one " + KeyInfo.ElementName + " in namespace " + Saml20Constants.Xmldsig)]
             public void ThrowsExceptionWhenKeyInfoConfirmationDataHasNoElementsWithValidKeyName()
             {
                 // Arrange
@@ -71,14 +70,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20SubjectConfirmationDataValidator();
 
                 // Act
-                validator.ValidateSubjectConfirmationData(subjectConfirmationData);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateSubjectConfirmationData(subjectConfirmationData),
+                    "SubjectConfirmationData element MUST contain at least one " + KeyInfo.ElementName + " in namespace " + Saml20Constants.Xmldsig);
             }
 
             /// <summary>
             /// Verify exception is thrown when key info confirmation data sub element has no children.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "KeyInfo subelement of SubjectConfirmationData MUST NOT be empty")]
             public void ThrowsExceptionWhenKeyInfoConfirmationDataSubElementHasNoChildren()
             {
                 // Arrange
@@ -89,14 +88,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20SubjectConfirmationDataValidator();
 
                 // Act
-                validator.ValidateSubjectConfirmationData(subjectConfirmationData);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateSubjectConfirmationData(subjectConfirmationData),
+                    "KeyInfo subelement of SubjectConfirmationData MUST NOT be empty");
             }
 
             /// <summary>
             /// Tests the validation of the SubjectConfirmationData recipient element
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Recipient of SubjectConfirmationData must be a wellformed absolute URI.")]
             public void ThrowsExceptionWhenSubjectConfirmationDataRecipientIsEmpty()
             {
                 // Arrange
@@ -104,14 +103,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20SubjectConfirmationDataValidator();
 
                 // Act
-                validator.ValidateSubjectConfirmationData(subjectConfirmationData);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateSubjectConfirmationData(subjectConfirmationData),
+                    "Recipient of SubjectConfirmationData must be a wellformed absolute URI.");
             }
 
             /// <summary>
             /// Tests the validation of the SubjectConfirmationData recipient element
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Recipient of SubjectConfirmationData must be a wellformed absolute URI.")]
             public void ThrowsExceptionWhenSubjectConfirmationDataRecipientIsInvalid()
             {
                 // Arrange
@@ -119,14 +118,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20SubjectConfirmationDataValidator();
 
                 // Act
-                validator.ValidateSubjectConfirmationData(subjectConfirmationData);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateSubjectConfirmationData(subjectConfirmationData),
+                    "Recipient of SubjectConfirmationData must be a wellformed absolute URI.");
             }
 
             /// <summary>
             /// Tests the validation of the SubjectConfirmationData {NotBefore, NotOnOrAfter} attributes
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "NotBefore 2008-01-30T17:13:00.5Z MUST BE less than NotOnOrAfter 2008-01-30T16:13:00.5Z on SubjectConfirmationData")]
             public void ThrowsExceptionWhenSubjectConfirmationDataTimeIntervalIsInvalid()
             {
                 // Arrange
@@ -137,7 +136,8 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20SubjectConfirmationDataValidator();
 
                 // Act
-                validator.ValidateSubjectConfirmationData(subjectConfirmationData);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateSubjectConfirmationData(subjectConfirmationData),
+                    "NotBefore 2008-01-30T17:13:00.5Z MUST BE less than NotOnOrAfter 2008-01-30T16:13:00.5Z on SubjectConfirmationData");
             }
 
             /// <summary>

--- a/src/SAML2.Tests/Validation/Saml20SubjectConfirmationValidatorTests.cs
+++ b/src/SAML2.Tests/Validation/Saml20SubjectConfirmationValidatorTests.cs
@@ -22,7 +22,6 @@ namespace SAML2.Tests.Validation
             /// Tests the validation of the SubjectConfirmation element
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "SubjectConfirmationData element MUST have at least one " + KeyInfo.ElementName + " subelement")]
             public void ThrowsExceptionWhenSubjectConfirmationDataDoesNotContainKeyInfo()
             {
                 // Arrange
@@ -35,14 +34,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20SubjectConfirmationValidator();
 
                 // Act
-                validator.ValidateSubjectConfirmation(subjectConfirmation);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateSubjectConfirmation(subjectConfirmation),
+                    "SubjectConfirmationData element MUST have at least one " + KeyInfo.ElementName + " subelement");
             }
 
             /// <summary>
             /// Tests the validation of the SubjectConfirmation element's method attribute.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Method attribute of SubjectConfirmation MUST contain at least one non-whitespace character")]
             public void ThrowsExceptionWhenSubjectConfirmationHasEmptyMethod()
             {
                 // Arrange
@@ -50,14 +49,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20SubjectConfirmationValidator();
 
                 // Act
-                validator.ValidateSubjectConfirmation(subjectConfirmation);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateSubjectConfirmation(subjectConfirmation),
+                    "Method attribute of SubjectConfirmation MUST contain at least one non-whitespace character");
             }
 
             /// <summary>
             /// Tests the validation of the SubjectConfirmation element's method attribute.
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "SubjectConfirmation element has Method attribute which is not a wellformed absolute uri.")]
             public void ThrowsExceptionWhenSubjectConfirmationHasWrongMethod()
             {
                 // Arrange
@@ -65,7 +64,8 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20SubjectConfirmationValidator();
 
                 // Act
-                validator.ValidateSubjectConfirmation(subjectConfirmation);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateSubjectConfirmation(subjectConfirmation),
+                    "SubjectConfirmation element has Method attribute which is not a wellformed absolute uri.");
             }
 
             /// <summary>

--- a/src/SAML2.Tests/Validation/Saml20SubjectValidatorTests.cs
+++ b/src/SAML2.Tests/Validation/Saml20SubjectValidatorTests.cs
@@ -21,7 +21,6 @@ namespace SAML2.Tests.Validation
             /// Tests the validation that ensures that a subject MUST have at least one sub element
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Subject MUST contain either an identifier or a subject confirmation")]
             public void ThrowsExceptionWhenSubjectConfirmationDoesNotContainSubject()
             {
                 // Arrange
@@ -31,14 +30,14 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20SubjectValidator();
 
                 // Act
-                validator.ValidateSubject(saml20Assertion.Subject);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateSubject(saml20Assertion.Subject),
+                    "Subject MUST contain either an identifier or a subject confirmation");
             }
 
             /// <summary>
             /// Tests the validation that ensures that a subject MUST have at least one sub element of correct type
             /// </summary>
             [Test]
-            [ExpectedException(typeof(Saml20FormatException), ExpectedMessage = "Subject must have either NameID, EncryptedID or SubjectConfirmation subelement.")]
             public void ThrowsExceptionWhenSubjectConfirmationContainsElementsOfWrongIdentifier()
             {
                 // Arrange
@@ -48,7 +47,8 @@ namespace SAML2.Tests.Validation
                 var validator = new Saml20SubjectValidator();
 
                 // Act
-                validator.ValidateSubject(saml20Assertion.Subject);
+                Assert.Throws<Saml20FormatException>(() => validator.ValidateSubject(saml20Assertion.Subject),
+                    "Subject must have either NameID, EncryptedID or SubjectConfirmation subelement.");
             }
         }
     }

--- a/src/SAML2.Tests/packages.config
+++ b/src/SAML2.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.2" targetFramework="net40" />
+  <package id="NUnit" version="3.8.1" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.45.0" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/src/SAML2/Config/IdentityProviderCollection.cs
+++ b/src/SAML2/Config/IdentityProviderCollection.cs
@@ -20,7 +20,7 @@ namespace SAML2.Config
         /// <summary>
         /// The file system watcher.
         /// </summary>
-        private readonly FileSystemWatcher _fileSystemWatcher;
+        private FileSystemWatcher _fileSystemWatcher;
 
         /// <summary>
         /// Contains Encoding instances of the the encodings that should by tried when a metadata file does not have its
@@ -50,19 +50,6 @@ namespace SAML2.Config
         {
             _fileInfo = new Dictionary<string, DateTime>();
             _fileToEntity = new Dictionary<string, string>();
-
-            _fileSystemWatcher = new FileSystemWatcher
-                                     {
-                                         Filter = "*.*",
-                                         NotifyFilter = NotifyFilters.LastAccess | NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName,
-                                         Path = MetadataLocation,
-                                         EnableRaisingEvents = true
-                                     };
-
-            _fileSystemWatcher.Changed += FileSystemWatcher_Changed;
-            _fileSystemWatcher.Created += FileSystemWatcher_Changed;
-            _fileSystemWatcher.Deleted += FileSystemWatcher_Changed;
-            _fileSystemWatcher.Renamed += FileSystemWatcher_Renamed;
         }
 
         #region Attributes
@@ -112,6 +99,33 @@ namespace SAML2.Config
         }
 
         #endregion
+
+        /// <summary>
+        /// Start watching files.
+        /// </summary>
+        public void EnableFileWatcher()
+        {
+            _fileSystemWatcher = new FileSystemWatcher
+            {
+                Filter = "*.*",
+                NotifyFilter = NotifyFilters.LastAccess | NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName,
+                Path = MetadataLocation,
+                EnableRaisingEvents = true
+            };
+
+            _fileSystemWatcher.Changed += FileSystemWatcher_Changed;
+            _fileSystemWatcher.Created += FileSystemWatcher_Changed;
+            _fileSystemWatcher.Deleted += FileSystemWatcher_Changed;
+            _fileSystemWatcher.Renamed += FileSystemWatcher_Renamed;
+        }
+
+        /// <summary>
+        /// Stops watching files.
+        /// </summary>
+        public void DisableFileWatcher()
+        {
+            _fileSystemWatcher.Dispose();
+        }
 
         /// <summary>
         /// Refreshes this instance from metadata location.

--- a/src/SAML2/Config/IdentityProviderCollection.cs
+++ b/src/SAML2/Config/IdentityProviderCollection.cs
@@ -84,7 +84,9 @@ namespace SAML2.Config
             set
             {
                 base["metadata"] = value;
-                _fileSystemWatcher.Path = MetadataLocation;
+                if (_fileSystemWatcher != null)
+                    _fileSystemWatcher.Path = MetadataLocation;
+
                 Refresh();
             }
         }
@@ -195,6 +197,18 @@ namespace SAML2.Config
 
                     _fileToEntity.Add(file, metadataDoc.EntityId);
                 }
+
+                if (_fileInfo.ContainsKey(file))
+                    _fileInfo[file] = File.GetLastWriteTime(file);
+                else
+                    _fileInfo.Add(file, File.GetLastWriteTime(file));
+            }
+
+            // Remove any IDPs with no metadata
+            var itemsToRemove = this.Where(x => x.Metadata == null).ToList();
+            foreach (var idp in itemsToRemove)
+            {
+                BaseRemove(idp.Id);
             }
         }
 

--- a/src/SAML2/Config/Saml2Config.cs
+++ b/src/SAML2/Config/Saml2Config.cs
@@ -20,17 +20,25 @@ namespace SAML2.Config
         {
             if (_config == null)
             {
-                _config = ConfigurationManager.GetSection(Saml2Section.Name) as Saml2Section;
-
-                if (_config == null)
-                {
-                    throw new ConfigurationErrorsException(string.Format("Configuration section \"{0}\" not found", typeof(Saml2Section).Name));
-                }
-
-                _config.IdentityProviders.Refresh();
+                Refresh();
             }
 
             return _config;
+        }
+
+        /// <summary>
+        /// Gets the base config element without additional metadata parsing, etc.
+        /// </summary>
+        /// <returns></returns>
+        public static Saml2Section GetConfigElement()
+        {
+            var config = ConfigurationManager.GetSection(Saml2Section.Name) as Saml2Section;
+            if (config == null)
+            {
+                throw new ConfigurationErrorsException(string.Format("Configuration section \"{0}\" not found", typeof(Saml2Section).Name));
+            }
+
+            return config;
         }
 
         /// <summary>
@@ -40,12 +48,7 @@ namespace SAML2.Config
         {
             _config = null;
             ConfigurationManager.RefreshSection(Saml2Section.Name);
-            _config = ConfigurationManager.GetSection(Saml2Section.Name) as Saml2Section;
-
-            if (_config == null)
-            {
-                throw new ConfigurationErrorsException(string.Format("Configuration section \"{0}\" not found", typeof(Saml2Section).Name));
-            }
+            _config = GetConfigElement();
 
             _config.IdentityProviders.Refresh();
         }

--- a/src/SAML2/Logging/LoggerProvider.cs
+++ b/src/SAML2/Logging/LoggerProvider.cs
@@ -23,7 +23,7 @@ namespace SAML2.Logging
         /// </summary>
         static LoggerProvider()
         {
-            var loggerClass = Saml2Config.GetConfig().Logging.LoggingFactory;
+            var loggerClass = Saml2Config.GetConfigElement().Logging.LoggingFactory;
             var loggerFactory = string.IsNullOrEmpty(loggerClass) ? new NoLoggingLoggerFactory() : GetLoggerFactory(loggerClass);
             SetLoggerFactory(loggerFactory);
         }


### PR DESCRIPTION
…possible circular call when an IDP metadata file can't be parsed, but a logger hasn't been instantiated yet.