### PR TITLE
Fixed issue with unrecognized bindings. Needed to work with SAMLTest.id

### DIFF
--- a/src/SAML2/Saml20MetadataDocument.cs
+++ b/src/SAML2/Saml20MetadataDocument.cs
@@ -614,7 +614,9 @@ namespace SAML2
                         }
 
                         if (descriptor.SingleSignOnService.Length > 0 && !_ssoEndpoints.Any())
+                        {
                             throw new InvalidOperationException("No supported SingleSignOnService bindings found");
+                        }
 
                         if (descriptor.SingleLogoutService != null)
                         {
@@ -644,7 +646,9 @@ namespace SAML2
                             }
 
                             if (descriptor.SingleLogoutService.Length > 0 && !_idpSloEndpoints.Any())
+                            {
                                 throw new InvalidOperationException("No supported SingleLogoutService bindings found");
+                            }
                         }
 
                         if (descriptor.ArtifactResolutionService != null)
@@ -685,7 +689,9 @@ namespace SAML2
                         }
 
                         if (descriptor.AssertionConsumerService.Length > 0 && !_assertionConsumerServiceEndpoints.Any())
+                        {
                             throw new InvalidOperationException("No supported AssertionConsumerService bindings found");
+                        }
 
 
                         if (descriptor.SingleLogoutService != null)
@@ -716,7 +722,9 @@ namespace SAML2
                             }
 
                             if (descriptor.SingleLogoutService.Length > 0 && !_spSloEndpoints.Any())
+                            {
                                 throw new InvalidOperationException("No supported SingleLogoutService bindings found");
+                            }
                         }
 
                         if (descriptor.ArtifactResolutionService != null)

--- a/src/SAML2/Saml20MetadataDocument.cs
+++ b/src/SAML2/Saml20MetadataDocument.cs
@@ -606,11 +606,15 @@ namespace SAML2
                                     binding = BindingType.Artifact;
                                     break;
                                 default:
-                                    throw new InvalidOperationException("Binding not supported: " + endpoint.Binding);
+                                    // throw new InvalidOperationException("Binding not supported: " + endpoint.Binding);
+                                    continue;
                             }
 
                             _ssoEndpoints.Add(new IdentityProviderEndpoint { Url = endpoint.Location, Binding = binding });
                         }
+
+                        if (descriptor.SingleSignOnService.Length > 0 && !_ssoEndpoints.Any())
+                            throw new InvalidOperationException("No supported SingleSignOnService bindings found");
 
                         if (descriptor.SingleLogoutService != null)
                         {
@@ -632,11 +636,15 @@ namespace SAML2
                                         binding = BindingType.Artifact;
                                         break;
                                     default:
-                                        throw new InvalidOperationException("Binding not supported: " + endpoint.Binding);
+                                        // throw new InvalidOperationException("Binding not supported: " + endpoint.Binding);
+                                        continue;
                                 }
 
                                 _idpSloEndpoints.Add(new IdentityProviderEndpoint { Url = endpoint.Location, Binding = binding });
                             }
+
+                            if (descriptor.SingleLogoutService.Length > 0 && !_idpSloEndpoints.Any())
+                                throw new InvalidOperationException("No supported SingleLogoutService bindings found");
                         }
 
                         if (descriptor.ArtifactResolutionService != null)
@@ -669,11 +677,16 @@ namespace SAML2
                                     binding = BindingType.Artifact;
                                     break;
                                 default:
-                                    throw new InvalidOperationException("Binding not supported: " + endpoint.Binding);
+                                    // throw new InvalidOperationException("Binding not supported: " + endpoint.Binding);
+                                    continue;
                             }
 
                             _assertionConsumerServiceEndpoints.Add(new IdentityProviderEndpoint { Url = endpoint.Location, Binding = binding });
                         }
+
+                        if (descriptor.AssertionConsumerService.Length > 0 && !_assertionConsumerServiceEndpoints.Any())
+                            throw new InvalidOperationException("No supported AssertionConsumerService bindings found");
+
 
                         if (descriptor.SingleLogoutService != null)
                         {
@@ -695,11 +708,15 @@ namespace SAML2
                                         binding = BindingType.Artifact;
                                         break;
                                     default:
-                                        throw new InvalidOperationException("Binding not supported: " + endpoint.Binding);
+                                        // throw new InvalidOperationException("Binding not supported: " + endpoint.Binding);
+                                        continue;
                                 }
 
                                 _spSloEndpoints.Add(new IdentityProviderEndpoint { Url = endpoint.Location, Binding = binding });
                             }
+
+                            if (descriptor.SingleLogoutService.Length > 0 && !_spSloEndpoints.Any())
+                                throw new InvalidOperationException("No supported SingleLogoutService bindings found");
                         }
 
                         if (descriptor.ArtifactResolutionService != null)


### PR DESCRIPTION
SAMLTest.ID's metadata (https://samltest.id/saml/sp) includes a Shibboleth binding definition before the supported binding types. That was causing a "Binding not supported" exception to be thrown. My change ignores unsupported bindings, but will throw an exception if no supported bindings are found.

