### PR TITLE
fixed certificat namespace when checking signature

### DIFF
--- a/src/SAML2/Utils/XmlSignatureUtils.cs
+++ b/src/SAML2/Utils/XmlSignatureUtils.cs
@@ -378,7 +378,7 @@ namespace SAML2.Utils
         private static List<X509Certificate2> GetCertificates(XmlDocument doc)
         {
             var certificates = new List<X509Certificate2>();
-            var nodeList = doc.GetElementsByTagName("ds:X509Certificate");
+            var nodeList = doc.GetElementsByTagName("X509Certificate", Saml20Constants.Xmldsig);
             if (nodeList.Count == 0)
             {
                 nodeList = doc.GetElementsByTagName("X509Certificate");


### PR DESCRIPTION
When checking the xml signature, the certificate is retrieved using an hardcoded namespace, which failed when the namespace is not named 'ds'.